### PR TITLE
fix: nexcloud desktop client couldn't sync for users with groupfolders

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -112,6 +112,10 @@ class Application extends App implements IBootstrap {
 				return;
 			}
 
+			if (str_contains($request->getPathInfo(), 'groupfolders')) {
+				return;
+			}
+
 			$debugModeEnabled = $config->getAppValue(self::APP_ID, self::APP_CONFIG_DEBUG_MODE, '0') === '1';
 
 			$token = $tokenService->getToken();


### PR DESCRIPTION
This app breaks the syncing with WebDav client including the Nextcloud Desktop Client when the user has group folder assigned.

We observed the following behavior with the Nextcloud Desktop Client:
- Assign a group folder to a user
- Connect the Desktop Client for the user
- Initial connection and sign in works
- The window to select the local folder is shown
- When accepting, the user is logged out and shown as offline

If the user doesn't have a group folder assigned, the same actions lead to a successful connection and the Client start syncing.

We solved the issue for now with the attached patch, but there is probably a better solution.