### PR TITLE
Fix header: let the logo expand by not expanding the central menu icon

### DIFF
--- a/src/components/CentralMenu.vue
+++ b/src/components/CentralMenu.vue
@@ -110,7 +110,6 @@ export default {
 
 <style lang="scss" scoped>
 #central-app-menu {
-	width: 100%;
 	display: flex;
 	flex-shrink: 1;
 	flex-wrap: wrap;


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/18dcdf32-52be-4bbd-ae1b-9abf2de58a8f)
After
![image](https://github.com/user-attachments/assets/2d2afcb5-6659-46ec-9c61-eb6583f6433e)

Remove the `width: 100%` of `#central-app-menu` so the logo can take the 138px we give it.

To reproduce, one can take the [OpenDesk logo](https://joinup.ec.europa.eu/sites/default/files/2023-09/A_openDesk_logo.png) (or any wide logo), set it as the instance logo in the theming settings and check the difference between v3.1.18 and v3.2.0.