### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5834,18 +5834,17 @@
 			}
 		},
 		"node_modules/compression": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-			"integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+			"integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"bytes": "3.1.2",
 				"compressible": "~2.0.18",
 				"debug": "2.6.9",
 				"negotiator": "~0.6.4",
-				"on-headers": "~1.0.2",
+				"on-headers": "~1.1.0",
 				"safe-buffer": "5.2.1",
 				"vary": "~1.1.2"
 			},
@@ -11699,11 +11698,10 @@
 			}
 		},
 		"node_modules/on-headers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+			"integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">= 0.8"


### PR DESCRIPTION
# Audit report

This audit fix resolves 2 of the total 2 vulnerabilities found in your project.

## Updated dependencies
* [compression](#user-content-compression)
* [on-headers](#user-content-on-headers)
## Fixed vulnerabilities

### compression <a href="#user-content-compression" id="compression">#</a>
* Caused by vulnerable dependency:
  * [on-headers](#user-content-on-headers)
* Affected versions: 1.0.3 - 1.8.0
* Package usage:
  * `node_modules/compression`

### on-headers <a href="#user-content-on-headers" id="on-headers">#</a>
* on-headers is vulnerable to http response header manipulation
* Severity: **low** (CVSS 3.4)
* Reference: [https://github.com/advisories/GHSA-76c9-3jph-rj3q](https://github.com/advisories/GHSA-76c9-3jph-rj3q)
* Affected versions: <1.1.0
* Package usage:
  * `node_modules/on-headers`