### PR TITLE
Do not check oidc token if we know user_oidc was not used to log in

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -112,11 +112,11 @@ class Application extends App implements IBootstrap {
 				return;
 			}
 
-			if (str_contains($request->getPathInfo(), 'groupfolders')) {
+			$debugModeEnabled = $config->getAppValue(self::APP_ID, self::APP_CONFIG_DEBUG_MODE, '0') === '1';
+
+			if (!$debugModeEnabled && !$tokenService->isUserOidcSession()) {
 				return;
 			}
-
-			$debugModeEnabled = $config->getAppValue(self::APP_ID, self::APP_CONFIG_DEBUG_MODE, '0') === '1';
 
 			$token = $tokenService->getToken();
 			if (!$debugModeEnabled && $token === null) {


### PR DESCRIPTION
This should prevent logouts from the desktop client for example. This integration app's `Application::boot()` should only run for browser sessions authenticated with user_oidc.

@raynay-r Could you try this PR and check if it still fixes the issue mentioned in #23?