### PR TITLE
Get token with user OIDC events if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
 
 ## OIDC token handling
 
+This app needs a valid OIDC token to get the central menu content and contact OpenXChange. We get this token from the user_oidc app.
+Depending on how user_oidc is configured, we either store and refresh the login token ourselves or rely on user_oidc to do so.
+
+If "Store login tokens" is enabled in user_oidc's admin settings, we know we can use the `OCA\UserOIDC\Event\ExternalTokenRequestedEvent`
+to ask user_oidc to provide the login token (or a refreshed one) instead of storing this token ourselves (and refreshing it).
+
 During login the access_token and refresh token are passed by the user_oidc app to the integration_swp app through a dispatched event.
 integration_swp will request a fresh token and regularly refresh it with the refresh token that was initially provided by the OpenID Connect login.
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -56,7 +56,7 @@ class PageController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[UseSession]
-	public function index() {
+	public function index(): JSONResponse {
 		/** @var Token $token */
 		$token = \OC::$server->get(TokenService::class)->getToken(true);
 		if ($token === null) {

--- a/lib/Listener/PublicShareTemplateLoader.php
+++ b/lib/Listener/PublicShareTemplateLoader.php
@@ -18,7 +18,7 @@ use OCP\IAppConfig;
 use OCP\Util;
 
 /**
- * @implements IEventListener<Event>
+ * @implements IEventListener<BeforeTemplateRenderedEvent>
  * Helper class to extend the "publicshare" template from the server.
  */
 class PublicShareTemplateLoader implements IEventListener {

--- a/lib/Listener/TokenObtainedEventListener.php
+++ b/lib/Listener/TokenObtainedEventListener.php
@@ -10,22 +10,18 @@ declare(strict_types=1);
 namespace OCA\Swp\Listener;
 
 use OCA\Swp\AppInfo\Application;
-//use OCA\Swp\Service\OxMailService;
 use OCA\Swp\Service\TokenService;
 use OCA\UserOIDC\Event\TokenObtainedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-//use OCP\Http\Client\IClientService;
 use Psr\Log\LoggerInterface;
 
 /**
- * @implements IEventListener<Event>
+ * @implements IEventListener<TokenObtainedEvent>
  */
 class TokenObtainedEventListener implements IEventListener {
 
 	public function __construct(
-		// private IClientService $clientService,
-		// private OxMailService $mailService,
 		private LoggerInterface $logger,
 		private TokenService $tokenService,
 	) {
@@ -39,39 +35,9 @@ class TokenObtainedEventListener implements IEventListener {
 
 		$token = $event->getToken();
 		$provider = $event->getProvider();
-		$discovery = $event->getDiscovery();
-
-		//$refreshToken = $token['refresh_token'] ?? null;
-
-		//if (!$refreshToken) {
-		//	$this->logger->debug('handle TokenObtainedEvent NO REFRESH TOKEN', ['app' => Application::APP_ID]);
-		//	return;
-		//}
-
-		//$client = $this->clientService->newClient();
-		//$this->logger->debug('TokenObtainedEventListener TOKEN REQUEST to ' . $discovery['token_endpoint'] . ' with refresh token=' . $refreshToken . ' and client id=' . $provider->getClientId(), ['app' => Application::APP_ID]);
-		//$result = $client->post(
-		//	$discovery['token_endpoint'],
-		//	[
-		//		'body' => [
-		//			'client_id' => $provider->getClientId(),
-		//			'client_secret' => $provider->getClientSecret(),
-		//			'grant_type' => 'refresh_token',
-		//			'refresh_token' => $refreshToken,
-		//			// TODO check if we need a different scope for this
-		//			'scope' => $provider->getScope(),
-		//		],
-		//	]
-		//);
-		//$this->logger->debug('refresh request STATUS CODE:' . $result->getStatusCode(), ['app' => Application::APP_ID]);
-
-		//$tokenData = json_decode($result->getBody(), true);
 
 		$tokenData = $token;
 		$this->logger->debug('Storing the token: ' . json_encode($tokenData), ['app' => Application::APP_ID]);
 		$this->tokenService->storeToken(array_merge($tokenData, ['provider_id' => $provider->getId()]));
-
-		//		$this->mailService->resetCache();
-		//		$this->mailService->fetchUnreadCounter();
 	}
 }

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -41,6 +41,11 @@ class Token implements JsonSerializable {
 		return $this->expiresIn;
 	}
 
+	public function getExpiresInFromNow(): int {
+		$expiresAt = $this->createdAt + $this->expiresIn;
+		return $expiresAt - time();
+	}
+
 	public function getRefreshToken(): string {
 		return $this->refreshToken;
 	}

--- a/lib/Service/OxMailService.php
+++ b/lib/Service/OxMailService.php
@@ -26,6 +26,7 @@ class OxMailService extends OxBaseService {
 	public function __construct(
 		ICacheFactory $cacheFactory,
 		TokenService $tokenService,
+		private IAppConfig $appConfig,
 		private IConfig $config,
 		private IAppConfig $appConfig,
 		private IClientService $clientService,

--- a/lib/Service/OxMailService.php
+++ b/lib/Service/OxMailService.php
@@ -26,7 +26,6 @@ class OxMailService extends OxBaseService {
 	public function __construct(
 		ICacheFactory $cacheFactory,
 		TokenService $tokenService,
-		private IAppConfig $appConfig,
 		private IConfig $config,
 		private IAppConfig $appConfig,
 		private IClientService $clientService,

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -109,7 +109,7 @@ class TokenService {
 		if ($refresh && $token->isExpiring()) {
 			$token = $this->refresh($token);
 		}
-		$this->logger->warning('[SWPTokenService] Obtained a token from our own session storage that expires in ' . $token->getExpiresInFromNow());
+		$this->logger->debug('[SWPTokenService] Obtained a token from our own session storage that expires in ' . $token->getExpiresInFromNow());
 		return $token;
 	}
 
@@ -130,7 +130,7 @@ class TokenService {
 			$this->logger->debug('There was no token found in the session');
 			return null;
 		} else {
-			$this->logger->warning('[SWPTokenService] Obtained a token from user_oidc that expires in ' . $userOidcToken->getExpiresInFromNow());
+			$this->logger->debug('[SWPTokenService] Obtained a token from user_oidc that expires in ' . $userOidcToken->getExpiresInFromNow());
 			return new Token([
 				'id_token' => $userOidcToken->getIdToken(),
 				'access_token' => $userOidcToken->getAccessToken(),

--- a/psalm.xml
+++ b/psalm.xml
@@ -39,6 +39,8 @@
 				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
 				<referencedClass name="OCA\UserOIDC\Db\Provider" />
 				<referencedClass name="OC\Authentication\Token\IProvider" />
+				<referencedClass name="OCA\UserOIDC\Exception\GetExternalTokenFailedException" />
+				<referencedClass name="OCA\UserOIDC\AppInfo\Application" />
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedDocblockClass>
@@ -52,5 +54,6 @@
 	<stubs>
 		<file name="tests/stubs/oc_hooks_emitter.php" />
 		<file name="tests/stubs/oca_events.php" />
+		<file name="tests/stubs/oca_user_oidc.php" />
 	</stubs>
 </psalm>

--- a/tests/stubs/oca_events.php
+++ b/tests/stubs/oca_events.php
@@ -16,19 +16,3 @@ namespace OCA\Files_Sharing\Event {
 		}
 	}
 }
-
-namespace OCA\UserOIDC\Event {
-
-	use OCP\EventDispatcher\Event;
-
-	class TokenObtainedEvent extends Event {
-		public function getToken(): array {
-		}
-
-		public function getProvider(): \OCA\UserOIDC\Db\Provider {
-		}
-
-		public function getDiscovery(): array {
-		}
-	}
-}

--- a/tests/stubs/oca_user_oidc.php
+++ b/tests/stubs/oca_user_oidc.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Event {
+
+	use OCP\EventDispatcher\Event;
+
+	class TokenObtainedEvent extends Event {
+		public function getToken(): array {
+		}
+
+		public function getProvider(): \OCA\UserOIDC\Db\Provider {
+		}
+
+		public function getDiscovery(): array {
+		}
+	}
+
+	class ExternalTokenRequestedEvent extends Event {
+		public function getToken(): ?\OCA\UserOIDC\Model\Token {
+		}
+	}
+}
+namespace OCA\UserOIDC\Model {
+	class Token {
+		public function getAccessToken(): string {
+		}
+
+		public function getIdToken(): ?string {
+		}
+
+		public function getExpiresIn(): int {
+		}
+
+		public function getExpiresInFromNow(): int {
+		}
+
+		public function getRefreshExpiresIn(): ?int {
+		}
+
+		public function getRefreshExpiresInFromNow(): int {
+		}
+
+		public function getRefreshToken(): ?string {
+		}
+
+		public function getProviderId(): ?int {
+		}
+
+		public function isExpired(): bool {
+		}
+
+		public function isExpiring(): bool {
+		}
+
+		public function refreshIsExpired(): bool {
+		}
+
+		public function refreshIsExpiring(): bool {
+		}
+
+		public function getCreatedAt() {
+		}
+
+		public function jsonSerialize(): array {
+		}
+	}
+}


### PR DESCRIPTION
If the "store login tokens" option is enabled in user_oidc, integration_swp should let user_oidc deal with token storage and refresh. We can use the `OCA\UserOIDC\Event\ExternalTokenRequestedEvent` event to get an up-to-date token.

<img width="474" height="196" alt="image" src="https://github.com/user-attachments/assets/78a8b873-78e5-46ed-92bf-c30e10550533" />

If both integration_swp and user_oidc are trying to refresh the same token at some point, one of them will fail because its token is outdated.