### PR TITLE
Avoid parallel login flows when a token expires

### DIFF
--- a/lib/Service/RequestClassificationService.php
+++ b/lib/Service/RequestClassificationService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Swp\Service;
+
+use OCP\IRequest;
+
+class RequestClassificationService {
+	public static function isTopLevelHtmlNavigation(IRequest $request): bool {
+		if (strtoupper($request->getMethod()) !== 'GET') {
+			return false;
+		}
+
+		$accept = strtolower($request->getHeader('Accept'));
+		if ($accept !== '' && strpos($accept, 'text/html') === false) {
+			return false;
+		}
+
+		if ($request->getHeader('X-Requested-With') === 'XMLHttpRequest') {
+			return false;
+		}
+
+		$secFetchMode = strtolower($request->getHeader('Sec-Fetch-Mode'));
+		if ($secFetchMode !== '' && $secFetchMode !== 'navigate') {
+			return false;
+		}
+
+		$secFetchDest = strtolower($request->getHeader('Sec-Fetch-Dest'));
+		if ($secFetchDest !== '' && $secFetchDest !== 'document') {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -212,10 +212,34 @@ class TokenService {
 			return;
 		}
 
+		$accept = $this->request->getHeader('Accept');
+		$xRequestedWith = $this->request->getHeader('X-Requested-With');
+		$secFetchMode = $this->request->getHeader('Sec-Fetch-Mode');
+		$secFetchDest = $this->request->getHeader('Sec-Fetch-Dest');
+		if (!RequestClassificationService::isTopLevelHtmlNavigation($this->request)) {
+			$this->userSession->logout();
+			$this->logger->debug('[TokenService] reauthenticate skipped: request is not a top-level HTML navigation', [
+				'request_uri' => $this->request->getRequestUri(),
+				'accept' => $accept,
+				'x_requested_with' => $xRequestedWith,
+				'sec_fetch_mode' => $secFetchMode,
+				'sec_fetch_dest' => $secFetchDest,
+			]);
+			return;
+		}
+
 		// Logout the user and redirect to the oidc login flow to gather a fresh token
 		$this->userSession->logout();
 		$redirectUrl = $this->urlGenerator->getAbsoluteURL('/index.php/apps/user_oidc/login/' . strval($token->getProviderId()))
 			. '?redirectUrl=' . urlencode($this->request->getRequestUri());
+		$this->logger->debug('[TokenService] reauthenticate redirect', [
+			'redirect_url' => $redirectUrl,
+			'request_uri' => $this->request->getRequestUri(),
+			'accept' => $accept,
+			'x_requested_with' => $xRequestedWith,
+			'sec_fetch_mode' => $secFetchMode,
+			'sec_fetch_dest' => $secFetchDest,
+		]);
 		header('Location: ' . $redirectUrl);
 		exit();
 	}


### PR DESCRIPTION
When the token has expired, only redirect to the login flow when the request comes from a 'navigation' context.

This is a complement to https://github.com/nextcloud/user_oidc/pull/1410 which is the real fix.